### PR TITLE
fix: dev: Removing docker-specific code. This closes #4.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,13 +2,12 @@
     "node_name": "your_node",
     "platform_engine_name": "your_platform_engine",
     "class_name": "node_class_name",
-    "default_docker_image": "your_default_docker_image",
     "author": "Hewlett Packard Enterprise Development LP",
     "email": "hpe-networking@lists.hp.com",
     "repo_url": "https://github.com/HPENetworking/{{ cookiecutter.platform_engine_name }}_{{ cookiecutter.node_name }}",
     "doc_url": "{{ cookiecutter.repo_url }}/tree/master/doc",
     "project_name": "{{ cookiecutter.node_name }} node for {{ cookiecutter.platform_engine_name }}",
-    "short_description": "A short description of your node.",
+    "short_description": "A {{ cookiecutter.node_name }} node for {{ cookiecutter.platform_engine_name }}.",
     "year": "2016",
     "version": "0.1.0"
 }

--- a/{{cookiecutter.platform_engine_name}}_{{cookiecutter.node_name}}/.cookiecutter.json
+++ b/{{cookiecutter.platform_engine_name}}_{{cookiecutter.node_name}}/.cookiecutter.json
@@ -2,7 +2,6 @@
     "node_name": "{{ cookiecutter.node_name }}",
     "platform_engine_name": "{{ cookiecutter.platform_engine_name }}",
     "class_name": "{{ cookiecutter.class_name }}",
-    "default_docker_image": "your_default_docker_image",
     "author": "{{ cookiecutter.author }}",
     "email": "{{ cookiecutter.email }}",
     "repo_url": "{{ cookiecutter.repo_url }}",

--- a/{{cookiecutter.platform_engine_name}}_{{cookiecutter.node_name}}/lib/{{cookiecutter.platform_engine_name}}_{{cookiecutter.node_name}}/{{ cookiecutter.node_name }}.py
+++ b/{{cookiecutter.platform_engine_name}}_{{cookiecutter.node_name}}/lib/{{cookiecutter.platform_engine_name}}_{{cookiecutter.node_name}}/{{ cookiecutter.node_name }}.py
@@ -16,32 +16,35 @@
 # under the License.
 
 """
-Simple host Topology Docker Node using Ubuntu.
+Cookiecutter Topology Node module
 """
 
 from __future__ import unicode_literals, absolute_import
 from __future__ import print_function, division
 
-from topology_docker.node import DockerNode
-from topology_docker.shell import DockerShell
+# Topology already includes a base class for nodes that includes certain
+# capabilities commonly used. This can be changed or removed if necessary.
+from topology.node import CommonNode
+
+# Same for the base shell imported here, this class incorporates common shell
+# utilities and can be changed or removed if necessary too.
+from topology.shell import PexpectBashShell
 
 
-class {{ cookiecutter.class_name }}(DockerNode):
+class {{ cookiecutter.class_name }}(CommonNode):
     """
-    {{ cookiecutter.node_name }} for the Topology Docker platform engine.
+    {{ cookiecutter.node_name }} for the {{ cookiecutter.platform_engine }} platform engine.
 
-    See :class:`topology_docker.node.DockerNode`.
+    See :class:`topology.base.CommonNode` for more information.
     """
 
     # Change this method as needed
-    def __init__(self, identifier, image='{{ cookiecutter.default_docker_image }}', **kwargs):
+    def __init__(self, identifier, **kwargs):
 
-        super({{ cookiecutter.class_name }}, self).__init__(identifier, image=image, **kwargs)
+        super({{ cookiecutter.class_name }}, self).__init__(identifier, **kwargs)
 
         # Set your shells as needed
-        self._shells['bash'] = DockerShell(
-            self.container_id, 'sh -c "TERM=dumb bash"', 'root@.*:.*# '
-        )
+        self._shells['bash'] = PexpectBashShell()
 
 
 __all__ = ['{{ cookiecutter.class_name }}']


### PR DESCRIPTION
This removes all docker-specific code that should not be here since this is a generic node cookiecutter.
