### PR TITLE
fix: dev: Adding platform engine as dependency. This closes #3.

### DIFF
--- a/{{cookiecutter.platform_engine_name}}_{{cookiecutter.node_name}}/requirements.dev.txt
+++ b/{{cookiecutter.platform_engine_name}}_{{cookiecutter.node_name}}/requirements.dev.txt
@@ -6,3 +6,4 @@ sphinx
 sphinx_rtd_theme
 sphinxcontrib-plantuml
 autoapi
+{{ cookiecutter.platform_engine_name }}


### PR DESCRIPTION
The `requirements.dev.txt` file was missing the platform engine as dependency. This fixes that.
