### PR TITLE
fix: dev: Fixing typo in base shell import. This closes #1.

### DIFF
--- a/{{cookiecutter.platform_engine_name}}_{{cookiecutter.node_name}}/lib/{{cookiecutter.platform_engine_name}}_{{cookiecutter.node_name}}/{{ cookiecutter.node_name }}.py
+++ b/{{cookiecutter.platform_engine_name}}_{{cookiecutter.node_name}}/lib/{{cookiecutter.platform_engine_name}}_{{cookiecutter.node_name}}/{{ cookiecutter.node_name }}.py
@@ -28,7 +28,7 @@ from topology.node import CommonNode
 
 # Same for the base shell imported here, this class incorporates common shell
 # utilities and can be changed or removed if necessary too.
-from topology.shell import PexpectBashShell
+from topology.shell import PExpectBashShell
 
 
 class {{ cookiecutter.class_name }}(CommonNode):


### PR DESCRIPTION
There was a typo in a API shell used now for the nodes. This fixes that.
